### PR TITLE
Add unit tests for new chat controllers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,21 @@
 			<artifactId>spring-boot-devtools</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
+			<version>5.2.0</version> <!-- or latest -->
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/practiceproject/linkchat_back/LinkchatBackApplication.java
+++ b/src/main/java/com/practiceproject/linkchat_back/LinkchatBackApplication.java
@@ -7,10 +7,15 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.concurrent.Executor;
+
 @SpringBootApplication
+@EnableAsync
 public class LinkchatBackApplication {
 
 //	@Bean
@@ -27,5 +32,16 @@ public class LinkchatBackApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(LinkchatBackApplication.class, args);
+	}
+
+	@Bean
+	public Executor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(5);
+		executor.setMaxPoolSize(10);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("AsyncEmail-");
+		executor.initialize();
+		return executor;
 	}
 }

--- a/src/main/java/com/practiceproject/linkchat_back/viewController/ChatsManagementController.java
+++ b/src/main/java/com/practiceproject/linkchat_back/viewController/ChatsManagementController.java
@@ -137,6 +137,8 @@ public class ChatsManagementController {
             return "new-chat";
         }
 
+        chatService.addInviteEmail(form, null);
+        logger.info("::Adding invite emails and to send invite email: {}", form.getInviteEmails());
         chatService.saveChat(form);
         emailService.sendInviteEmail(emailRequest, form);
         logger.info("::New chat saved and invite email sent to: {}", emailRequest.getTo());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,3 +32,8 @@ springdoc.swagger-ui.path=/api/swagger-ui.html
 
 spring.thymeleaf.cache=false
 spring.devtools.livereload.enabled=true
+
+# These properties can be used to customize the email content and sender information
+app.base-url=https://fs-dev.portnov.com
+app.fromEmail=sysportnov@gmail.com
+app.emailSubject="You?ve got a chat invite!"

--- a/src/test/java/com/practiceproject/linkchat_back/viewController/ChatsManagementControllerTest.java
+++ b/src/test/java/com/practiceproject/linkchat_back/viewController/ChatsManagementControllerTest.java
@@ -1,0 +1,147 @@
+package com.practiceproject.linkchat_back.viewController;
+
+import com.practiceproject.linkchat_back.dtos.SimpleEmailRequest;
+import com.practiceproject.linkchat_back.model.Chat;
+import com.practiceproject.linkchat_back.services.ChatService;
+import com.practiceproject.linkchat_back.services.EmailService;
+import com.practiceproject.linkchat_back.viewModels.ChatForm;
+import com.practiceproject.linkchat_back.repository.ChatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.ui.ConcurrentModel;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class ChatsManagementControllerTest {
+
+    @Mock
+    private ChatService chatService;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private RedirectAttributes redirectAttributes;
+
+    @Mock
+    private SimpleEmailRequest request;
+
+    @InjectMocks
+    private ChatsManagementController controller;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+
+    @Test
+    void showChatForm_ShouldAddChatFormToModel_WhenNotPresent() {
+        // Arrange
+        Model model = new ConcurrentModel();
+        ChatForm mockForm = new ChatForm();
+        when(chatService.createDefaultChatForm()).thenReturn(mockForm);
+
+        // Act
+        String view = controller.showChatForm(model);
+
+        // Assert
+        assertEquals("new-chat", view);
+        assertTrue(model.containsAttribute("chat"));
+        assertEquals(mockForm, model.getAttribute("chat"));
+    }
+
+    @Test
+    void showChatForm_ShouldNotOverwriteChatForm_WhenAlreadyPresent() {
+        // Arrange
+        Model model = new ConcurrentModel();
+        ChatForm existingForm = new ChatForm();
+        model.addAttribute("chat", existingForm);
+
+        // Act
+        String view = controller.showChatForm(model);
+
+        // Assert
+        assertEquals("new-chat", view);
+        assertEquals(existingForm, model.getAttribute("chat"));
+        verify(chatService, never()).createDefaultChatForm();
+    }
+
+    @Test
+    void testGenerateLink() {
+        // Given
+        ChatForm form = new ChatForm();
+
+        // When
+        String view = controller.generateLink(form, redirectAttributes);
+
+        // Then
+        verify(chatService, times(1)).generateRandomLink(form);
+        verify(redirectAttributes, times(1)).addFlashAttribute("chat", form);
+        assertEquals("redirect:/ui/new-chat", view);
+    }
+
+    @Test
+    void saveNewChat_ShouldSaveChatAndRedirect_WhenNoValidationErrors() {
+        // Arrange
+        ChatForm form = new ChatForm();
+        form.setTitle("Test Chat");
+        form.setLink("link123");
+        // Set other fields if needed
+
+        BindingResult bindingResult = Mockito.mock(BindingResult.class);
+        when(bindingResult.hasErrors()).thenReturn(false);  // no validation errors
+
+        // Act
+        String view = controller.saveNewChat(form, bindingResult);
+
+        // Assert
+        verify(chatService).addInviteEmail(eq(form), isNull());
+        verify(chatService).saveChat(form);
+        assertEquals("redirect:/ui/chats-management", view);
+    }
+
+    @Test
+    void saveNewChat_ShouldReturnFormView_WhenValidationErrorsExist() {
+        // Arrange
+        ChatForm form = new ChatForm();
+        BindingResult bindingResult = Mockito.mock(BindingResult.class);
+        when(bindingResult.hasErrors()).thenReturn(true);  // simulate validation errors
+
+        // Act
+        String view = controller.saveNewChat(form, bindingResult);
+
+        // Assert
+        verify(chatService, never()).saveChat(any());
+        assertEquals("new-chat", view);
+    }
+
+    @Test
+    void saveAndSendNewChat_ShouldSaveChatAndSendEmailAndRedirect() throws Exception {
+        // Arrange
+        ChatForm form = new ChatForm();
+        form.setLink("abc123");
+        // set other fields if needed
+
+        SimpleEmailRequest emailRequest = new SimpleEmailRequest();
+        emailRequest.setTo("user@example.com");
+        // set other fields if needed
+
+        BindingResult bindingResult = Mockito.mock(BindingResult.class);
+        when(bindingResult.hasErrors()).thenReturn(false);  // simulate no validation errors
+
+        // Act
+        String view = controller.saveAndSendNewChat(form, bindingResult, emailRequest);
+
+        // Assert
+        verify(chatService).saveChat(form);
+        verify(emailService).sendInviteEmail(emailRequest, form);
+        assertEquals("redirect:/ui/chats-management", view);
+    }
+}


### PR DESCRIPTION
- Added unit tests for new chat controllers
- Moved email sender properties to application.properties for ease of maintenance and customization.
- BUG_FIX: Timestamp of emails now save in DB after clicking Save&Send